### PR TITLE
using unchecked to improve gas efficiency

### DIFF
--- a/erc20/ERC20-XTT-Contract.sol
+++ b/erc20/ERC20-XTT-Contract.sol
@@ -359,10 +359,10 @@ pragma solidity 0.8.1;
 	
 	        uint256 accountBalance = _balances[account];
 	        require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
-			unchecked {
-				_balances[account] = accountBalance - amount;
-				_totalSupply -= amount;
-			}
+	        unchecked {
+	            _balances[account] = accountBalance - amount;
+	            _totalSupply -= amount;
+	        }
 	        
 	        emit Transfer(account, address(0), amount);
 	    }

--- a/erc20/ERC20-XTT-Contract.sol
+++ b/erc20/ERC20-XTT-Contract.sol
@@ -241,9 +241,11 @@ pragma solidity 0.8.1;
 	        _transfer(sender, recipient, amount);
 	
 	        uint256 currentAllowance = _allowances[sender][_msgSender()];
-	        require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
-	        _approve(sender, _msgSender(), currentAllowance - amount);
-	
+            require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
+            unchecked {
+                _approve(sender, _msgSender(), currentAllowance - amount);
+            }
+
 	        return true;
 	    }
 	
@@ -281,8 +283,10 @@ pragma solidity 0.8.1;
 	    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
 	        uint256 currentAllowance = _allowances[_msgSender()][spender];
 	        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
-	        _approve(_msgSender(), spender, currentAllowance - subtractedValue);
-	
+            unchecked {
+                _approve(_msgSender(), spender, currentAllowance - subtractedValue);
+            }
+
 	        return true;
 	    }
 	
@@ -308,8 +312,10 @@ pragma solidity 0.8.1;
 	
 	        uint256 senderBalance = _balances[sender];
 	        require(senderBalance >= amount, "ERC20: transfer amount exceeds balance");
-	        _balances[sender] = senderBalance - amount;
-	        _balances[recipient] += amount;
+			unchecked {
+				_balances[sender] = senderBalance - amount;
+                _balances[recipient] += amount;	
+			}
 	
 	        emit Transfer(sender, recipient, amount);
 	    }
@@ -329,7 +335,9 @@ pragma solidity 0.8.1;
 	        _beforeTokenTransfer(address(0), account, amount);
 	
 	        _totalSupply += amount;
-	        _balances[account] += amount;
+			unchecked {
+				_balances[account] += amount;
+			}
 	        emit Transfer(address(0), account, amount);
 	    }
 	
@@ -351,9 +359,11 @@ pragma solidity 0.8.1;
 	
 	        uint256 accountBalance = _balances[account];
 	        require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
-	        _balances[account] = accountBalance - amount;
-	        _totalSupply -= amount;
-	
+			unchecked {
+				_balances[account] = accountBalance - amount;
+				_totalSupply -= amount;
+			}
+	        
 	        emit Transfer(account, address(0), amount);
 	    }
 	
@@ -424,7 +434,9 @@ pragma solidity 0.8.1;
 	    function burnFrom(address account, uint256 amount) public virtual {
 	        uint256 currentAllowance = allowance(account, _msgSender());
 	        require(currentAllowance >= amount, "ERC20: burn amount exceeds allowance");
-	        _approve(account, _msgSender(), currentAllowance - amount);
+			unchecked {
+				_approve(account, _msgSender(), currentAllowance - amount);
+			}
 	        _burn(account, amount);
 	    }
 	}

--- a/erc20/ERC20-XTT-Contract.sol
+++ b/erc20/ERC20-XTT-Contract.sol
@@ -241,10 +241,10 @@ pragma solidity 0.8.1;
 	        _transfer(sender, recipient, amount);
 	
 	        uint256 currentAllowance = _allowances[sender][_msgSender()];
-            require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
-            unchecked {
-                _approve(sender, _msgSender(), currentAllowance - amount);
-            }
+	        require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
+	        unchecked {
+	            _approve(sender, _msgSender(), currentAllowance - amount);
+	        }
 
 	        return true;
 	    }
@@ -283,9 +283,9 @@ pragma solidity 0.8.1;
 	    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
 	        uint256 currentAllowance = _allowances[_msgSender()][spender];
 	        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
-            unchecked {
-                _approve(_msgSender(), spender, currentAllowance - subtractedValue);
-            }
+	        unchecked {
+	            _approve(_msgSender(), spender, currentAllowance - subtractedValue);
+	        }
 
 	        return true;
 	    }
@@ -312,10 +312,10 @@ pragma solidity 0.8.1;
 	
 	        uint256 senderBalance = _balances[sender];
 	        require(senderBalance >= amount, "ERC20: transfer amount exceeds balance");
-			unchecked {
-				_balances[sender] = senderBalance - amount;
-                _balances[recipient] += amount;	
-			}
+	        unchecked {
+	            _balances[sender] = senderBalance - amount;
+	            _balances[recipient] += amount;	
+	        }
 	
 	        emit Transfer(sender, recipient, amount);
 	    }
@@ -335,9 +335,9 @@ pragma solidity 0.8.1;
 	        _beforeTokenTransfer(address(0), account, amount);
 	
 	        _totalSupply += amount;
-			unchecked {
-				_balances[account] += amount;
-			}
+	        unchecked {
+	            _balances[account] += amount;
+	        }
 	        emit Transfer(address(0), account, amount);
 	    }
 	
@@ -434,9 +434,9 @@ pragma solidity 0.8.1;
 	    function burnFrom(address account, uint256 amount) public virtual {
 	        uint256 currentAllowance = allowance(account, _msgSender());
 	        require(currentAllowance >= amount, "ERC20: burn amount exceeds allowance");
-			unchecked {
-				_approve(account, _msgSender(), currentAllowance - amount);
-			}
+	        unchecked {
+	            _approve(account, _msgSender(), currentAllowance - amount);
+	        }
 	        _burn(account, amount);
 	    }
 	}


### PR DESCRIPTION
For ERC20, _totalSupply is the sum of all values in _balances. Thus, in function _mint(), "_totalSupply += amount" does not overflow, which can guarantee all additions on _balances[account] or _balances[recipent] do not overflow. 

Similarly, subtractions on _totalSupply do not overflow, because subtraction on _balances[sender] conducted earlier does not overflow. 

There are several explicit checks (e.g., "senderBalance >= amount"), which can enable the use of unchecked.  